### PR TITLE
Update integration code to version 6 and add hooks into page(), user() and track()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -28,7 +28,7 @@ var WebEngage = module.exports = integration('WebEngage')
 WebEngage.prototype.initialize = function() {
   /* eslint-disable */
 
-  !function(e,t,n){function o(e,t){e[t[t.length-1]]=function(){r.__queue.push([t.join("."),arguments])}}var i,s,r=e[n],g=" ",l="init options track screen onReady".split(g),a="feedback survey notification".split(g),c="options render clear abort".split(g),p="Open Close Submit Complete View Click".split(g),u="identify login logout setAttribute".split(g);if(!r||!r.__v){for(e[n]=r={__queue:[],__v:"5.0",user:{}},i=0;i<l.length;i++)o(r,[l[i]]);for(i=0;i<a.length;i++){for(r[a[i]]={},s=0;s<c.length;s++)o(r[a[i]],[a[i],c[s]]);for(s=0;s<p.length;s++)o(r[a[i]],[a[i],"on"+p[s]])}for(i=0;i<u.length;i++)o(r.user,["user",u[i]]);}}(window,document,"webengage");
+  !function(e,t,n){function o(e,t){e[t[t.length-1]]=function(){r.__queue.push([t.join("."),arguments])}}var i,s,r=e[n],g=" ",l="init options track screen onReady".split(g),a="feedback survey notification".split(g),c="options render clear abort".split(g),p="Open Close Submit Complete View Click".split(g),u="identify login logout setAttribute".split(g);if(!r||!r.__v){for(e[n]=r={__queue:[],__v:"6.0",user:{}},i=0;i<l.length;i++)o(r,[l[i]]);for(i=0;i<a.length;i++){for(r[a[i]]={},s=0;s<c.length;s++)o(r[a[i]],[a[i],c[s]]);for(s=0;s<p.length;s++)o(r[a[i]],[a[i],"on"+p[s]])}for(i=0;i<u.length;i++)o(r.user,["user",u[i]]);}}(window,document,"webengage");
 
   window.webengage.ixP = 'Segment';
   /* eslint-enable */

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,24 +12,29 @@ var useHttps = require('use-https');
  */
 
 var WebEngage = module.exports = integration('WebEngage')
-  .assumesPageview()
-  .global('_weq')
+  .readyOnInitialize()
   .global('webengage')
-  .option('widgetVersion', '4.0')
   .option('licenseCode', '')
-  .tag('http', '<script src="http://cdn.widgets.webengage.com/js/widget/webengage-min-v-4.0.js">')
-  .tag('https', '<script src="https://ssl.widgets.webengage.com/js/widget/webengage-min-v-4.0.js">');
+  .tag('http', '<script src="http://cdn.widgets.webengage.com/js/webengage-min-v-6.0.js">')
+  .tag('https', '<script src="https://ssl.widgets.webengage.com/js/webengage-min-v-6.0.js">');
 
 /**
  * Initialize.
  *
+ * http://docs.webengage.com/docs/web-sdk-integration#section-integration-code
  * @api public
  */
 
 WebEngage.prototype.initialize = function() {
-  var _weq = window._weq = window._weq || {};
-  _weq['webengage.licenseCode'] = this.options.licenseCode;
-  _weq['webengage.widgetVersion'] = this.options.widgetVersion;
+  /* eslint-disable */
+
+  !function(e,t,n){function o(e,t){e[t[t.length-1]]=function(){r.__queue.push([t.join("."),arguments])}}var i,s,r=e[n],g=" ",l="init options track screen onReady".split(g),a="feedback survey notification".split(g),c="options render clear abort".split(g),p="Open Close Submit Complete View Click".split(g),u="identify login logout setAttribute".split(g);if(!r||!r.__v){for(e[n]=r={__queue:[],__v:"5.0",user:{}},i=0;i<l.length;i++)o(r,[l[i]]);for(i=0;i<a.length;i++){for(r[a[i]]={},s=0;s<c.length;s++)o(r[a[i]],[a[i],c[s]]);for(s=0;s<p.length;s++)o(r[a[i]],[a[i],"on"+p[s]])}for(i=0;i<u.length;i++)o(r.user,["user",u[i]]);}}(window,document,"webengage");
+
+  window.webengage.ixP = 'Segment';
+  /* eslint-enable */
+
+  window.webengage.init(this.options.licenseCode);
+
   var name = useHttps() ? 'https' : 'http';
   this.load(name, this.ready);
 };
@@ -44,3 +49,108 @@ WebEngage.prototype.initialize = function() {
 WebEngage.prototype.loaded = function() {
   return !!window.webengage;
 };
+
+
+/**
+ * Identify.
+ *
+ * http://docs.webengage.com/docs/web-sdk-user#section-webengage-user-login
+ *
+ * @api public
+ * @param {Identify} identify
+ */
+
+WebEngage.prototype.identify = function(identify) {
+  var traits = identify.traits();
+  var id = identify.userId();
+  if (id) window.webengage.user.login(id);
+
+  if (traits) window.webengage.user.setAttribute(mapTraits(traits));
+};
+
+
+/**
+ * Track.
+ *
+ * http://docs.webengage.com/docs/web-sdk-events#section-webengage-track
+ *
+ * @api public
+ * @param {Track} track
+ */
+
+WebEngage.prototype.track = function(track) {
+  var event = track.event();
+  var properties = track.properties();
+  window.webengage.track(event, properties);
+};
+
+
+/**
+ * Page.
+ *
+ * http://docs.webengage.com/docs/web-sdk-integration#section-webengage-screen
+ * @param {Page} page
+ */
+
+WebEngage.prototype.page = function(page) {
+  var name = page.name() || '';
+  var properties = page.properties();
+
+  window.webengage.screen(name, properties);
+};
+
+
+/**
+ * Map traits to their WebEngage attributes.
+ *
+ * http://docs.webengage.com/docs/web-sdk-user#section-reserved-attributes
+ *
+ * @param {Object} traits
+ * @return {Object} mapped
+ * @api private
+ */
+
+function mapTraits(traits) {
+  var aliases = {
+    name: 'we_first_name',
+    firstName: 'we_first_name',
+    lastName: 'we_last_name',
+    email: 'we_email',
+    gender: 'we_gender',
+    birthday: 'we_birth_date',
+    phone: 'we_phone',
+    company: 'we_company'
+  };
+
+  var mapped = {};
+  for (var k in traits) {
+    if (aliases.hasOwnProperty(k)) {
+      mapped[aliases[k]] = traits[k];
+    } else {
+      mapped[k] = traits[k];
+    }
+  }
+
+  if (Object.prototype.toString.call(mapped.we_birth_date) === '[object Date]') {
+    var date = mapped.we_birth_date;
+
+    mapped.we_birth_date = date.getUTCFullYear()
+      + '-' + pad(date.getUTCMonth() + 1)
+      + '-' + pad(date.getUTCDate());
+  }
+
+  return mapped;
+}
+
+
+/**
+ * Pad single digit numbers with a leading 0.
+ *
+ * @param {number} number
+ * @return {number}
+ * @api private
+ */
+
+function pad(number) {
+  return number < 10 ? '0' + number : number;
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -30,16 +30,199 @@ describe('WebEngage', function() {
 
   it('should store the correct settings', function() {
     analytics.compare(WebEngage, integration('WebEngage')
-      .assumesPageview()
+      .readyOnInitialize()
       .global('webengage')
-      .global('_weq')
-      .option('widgetVersion', '4.0')
       .option('licenseCode', ''));
   });
+
+  describe('before loading', function() {
+    beforeEach(function() {
+      analytics.stub(webengage, 'load');
+      analytics.initialize();
+      analytics.page();
+    });
+
+    describe('#initialize', function() {
+      it('should create window.webengage', function() {
+        analytics.assert(window.webengage);
+      });
+
+      it('should create window.webengage.screen', function() {
+        analytics.assert(window.webengage.screen);
+      });
+
+      it('should create window.webengage.track', function() {
+        analytics.assert(window.webengage.screen);
+      });
+
+      it('should create window.webengage.user.login', function() {
+        analytics.assert(window.webengage.user.login);
+      });
+
+      it('should create window.webengage.user.setAttribute', function() {
+        analytics.assert(window.webengage.user.setAttribute);
+      });
+    });
+  });
+
+  // describe('loading', function() {
+  //   it('should load and be ready', function(done) {
+  //     analytics.load(webengage, function(err) {
+  //       if (err) {
+  //         done(err);
+  //       }
+
+  //       setTimeout(function() {
+  //         done(new Error('did load but was not ready in 8 seconds'));
+  //       }, 8000);
+
+  //       window.webengage.onReady(done);
+  //     });
+  //   });
+  // });
 
   describe('loading', function() {
     it('should load', function(done) {
       analytics.load(webengage, done);
+    });
+  });
+
+  describe('after loading', function() {
+    beforeEach(function(done) {
+      analytics.initialize();
+      analytics.page();
+      analytics.once('ready', done);
+    });
+
+    describe('#page', function() {
+      beforeEach(function() {
+        analytics.stub(window.webengage, 'screen');
+      });
+
+      it('should call screen', function() {
+        analytics.page();
+        analytics.called(window.webengage.screen);
+      });
+
+      it('should pass page name and default properties via screen', function() {
+        analytics.page('Name');
+        analytics.called(window.webengage.screen, 'Name', {
+          title: document.title,
+          url: window.location.href,
+          name: 'Name',
+          path: window.location.pathname,
+          referrer: document.referrer,
+          search: window.location.search
+        });
+      });
+
+      it('should pass page name and properties (some overridden) via screen', function() {
+        analytics.page('Arbitrary category', 'Name', {
+          title: 'Multi-channel User Engagement & Marketing Automation Platform - WebEngage',
+          url: 'https://webengage.com',
+          custom: 'Custom property'
+        });
+        analytics.called(window.webengage.screen, 'Name', {
+          title: 'Multi-channel User Engagement & Marketing Automation Platform - WebEngage',
+          url: 'https://webengage.com',
+          name: 'Name',
+          path: window.location.pathname,
+          referrer: document.referrer,
+          search: window.location.search,
+          category: 'Arbitrary category',
+          custom: 'Custom property'
+        });
+      });
+    });
+
+    describe('#identify', function() {
+      beforeEach(function() {
+        analytics.stub(window.webengage.user, 'login');
+        analytics.stub(window.webengage.user, 'setAttribute');
+      });
+
+      it('should send an id', function() {
+        analytics.identify('id');
+        analytics.called(window.webengage.user.login, 'id');
+        analytics.called(window.webengage.user.setAttribute, {
+          id: 'id'
+        });
+      });
+
+      it('should send traits', function() {
+        analytics.identify({
+          trait: true
+        });
+        analytics.didNotCall(window.webengage.user.login);
+        analytics.called(window.webengage.user.setAttribute, {
+          trait: true
+        });
+      });
+
+      it('should send an id and traits', function() {
+        analytics.identify('id', {
+          trait: true
+        });
+        analytics.called(window.webengage.user.login, 'id');
+        analytics.called(window.webengage.user.setAttribute, {
+          trait: true,
+          id: 'id'
+        });
+      });
+
+      it('should send mapped traits to their reserved WebEngage user attributes', function() {
+        analytics.identify('id', {
+          firstName: 'John',
+          lastName: 'Doe',
+          email: 'johndoe@anonymous.org',
+          gender: 'male',
+          birthday: '1970-01-01',
+          phone: '333-444-1234',
+          company: 'Acme Inc'
+        });
+        analytics.called(window.webengage.user.login, 'id');
+        analytics.called(window.webengage.user.setAttribute, {
+          we_first_name: 'John',
+          we_last_name: 'Doe',
+          we_email: 'johndoe@anonymous.org',
+          we_gender: 'male',
+          we_birth_date: '1970-01-01',
+          we_phone: '333-444-1234',
+          we_company: 'Acme Inc',
+          id: 'id'
+        });
+      });
+
+      it('should convert the "birthday" trait to a yyyy-mm-dd (UTC) string for we_birth_date user attribute', function() {
+        analytics.identify('id', {
+          birthday: new Date('Wed, 3 Apr 2001 00:00:00 UTC')
+        });
+        analytics.called(window.webengage.user.login, 'id');
+        analytics.called(window.webengage.user.setAttribute, {
+          we_birth_date: '2001-04-03',
+          id: 'id'
+        });
+      });
+    });
+
+    describe('#track', function() {
+      beforeEach(function() {
+        analytics.stub(window.webengage, 'track');
+      });
+
+      it('should send an event', function() {
+        analytics.track('event');
+        analytics.called(window.webengage.track, 'event', {});
+      });
+
+      it('should send an event and properties', function() {
+        analytics.track('event', {
+          property: true
+        });
+        analytics.called(window.webengage.track, 'event', {
+          property: true
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
Per the conversation in #1, we rebased our code on the current master and have made some more updates
- Embeds latest integration code (version 6)
- No more '_weq' global and 'widgetVersion' option
- Integration does not assumesPageview() simply to capture any
  initial page name, data
- Integration is readyOnInitialize()
- WebEngage 2.0 features data collection capablities - event
  tracking, identifying users with their attributes etc.
- Existing test cases updated
- Added test sections #page, #user and #track
